### PR TITLE
Cache docker-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ clean:
 
 .PHONY: docker-build
 docker-build:
-	docker pull jonlauridsen/node-nexe:10-alpine
-	docker build -f docker-images/node-nexe-10-alpine.Dockerfile -t jonlauridsen/node-nexe:10-alpine .
+	docker pull jonlauridsen/node-nexe:10-alpine || true
+	docker build -f docker-images/node-nexe-10-alpine.Dockerfile --cache-from jonlauridsen/node-nexe:10-alpine -t jonlauridsen/node-nexe:10-alpine .
 
 .PHONY: docker-publish
 docker-publish:


### PR DESCRIPTION
The whole point was to cache the docker-build, but it turns out to do that we need to use the "--cache-from" command.